### PR TITLE
added vpn scripts

### DIFF
--- a/router/start-vpn.ash
+++ b/router/start-vpn.ash
@@ -1,0 +1,80 @@
+#!/bin/ash
+
+opkg update
+
+# Install required packages
+opkg install wireguard-tools luci-proto-wireguard curl
+
+echo "packages installed, starting wireguard setup..."
+
+# Load WireGuard kernel module
+modprobe wireguard
+
+# Enable WireGuard service
+# /etc/init.d/network restart
+
+# Generate WireGuard key pair
+private_key=$(wg genkey)
+public_key=$(echo "$private_key" | wg pubkey)
+
+mullvad_ip=$(curl -s -d "account=0129241754650412" --data-urlencode "pubkey=$public_key" https://api.mullvad.net/wg/)
+
+address=$(echo "$mullvad_ip" | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}')
+
+# Create WireGuard interface
+uci set network.WGINTERFACE=interface
+uci set network.WGINTERFACE.proto='wireguard'
+uci set network.WGINTERFACE.private_key=$private_key
+uci set network.WGINTERFACE.addresses=$address
+uci set network.WGINTERFACE.force_link='1'
+
+# Add WireGuard peer configuration 
+uci add network wireguard_WGINTERFACE
+uci set network.@wireguard_WGINTERFACE[0]=wireguard_WGINTERFACE
+uci set network.@wireguard_WGINTERFACE[0].public_key='k4ah0qvHgn5IsalvehE7GPiDC4BOE9botvd+KITdtyg='
+uci set network.@wireguard_WGINTERFACE[0].allowed_ips='0.0.0.0/0'
+uci set network.@wireguard_WGINTERFACE[0].route_allowed_ips='1'
+uci set network.@wireguard_WGINTERFACE[0].endpoint_host='199.229.250.59'
+uci set network.@wireguard_WGINTERFACE[0].endpoint_port='51820'
+
+uci add firewall zone
+uci set firewall.@zone[-1].name='WGZONE'
+uci set firewall.@zone[-1].input='REJECT'
+uci set firewall.@zone[-1].output='ACCEPT'
+uci set firewall.@zone[-1].forward='REJECT'
+uci set firewall.@zone[-1].masq='1'
+uci set firewall.@zone[-1].mtu_fix='1'
+uci set firewall.@zone[-1].network='WGINTERFACE'
+
+uci add firewall forwarding
+uci set firewall.@forwarding[-1].src='lan'
+uci set firewall.@forwarding[-1].dest='WGZONE'
+
+
+# Commit changes
+uci commit network
+uci commit firewall
+
+uci set network.lan.ipaddr='192.168.99.1'
+
+uci set dhcp.lan.dhcp_option='6,10.64.0.1'
+
+uci set firewall.@zone[1].forward='WGZONE:WGINTERFACE'
+uci commit firewall
+
+echo "finished setup"
+echo "Private Key: $private_key"
+echo "Public Key: $public_key"
+echo "Mullvad IP: $mullvad_ip"
+
+
+# Restart network service
+/etc/init.d/network restart
+
+# Restart firewall service
+/etc/init.d/firewall restart
+
+echo "WireGuard keys generated and interface configured:"
+echo "Private Key: $private_key"
+echo "Public Key: $public_key"
+echo "Mullvad IP: $mullvad_ip"

--- a/router/stop-vpn.ash
+++ b/router/stop-vpn.ash
@@ -1,0 +1,39 @@
+
+ "Stopping WireGuard VPN..."
+
+# Delete the WireGuard interface and peer configuration
+uci -q delete network.WGINTERFACE
+uci -q delete network.wireguard_WGINTERFACE
+
+# Check if 'WGZONE' exists in the firewall configuration and delete it
+if uci -q get firewall.WGZONE >/dev/null; then
+  uci -q delete firewall.WGZONE
+fi
+
+# Check if there's a forwarding rule from lan to WGZONE and delete it
+if uci -q get firewall.@forwarding[-1].src='lan' >/dev/null; then
+  uci -q delete firewall.@forwarding[-1]
+fi
+
+# Remove DHCP-Options for the lan interface
+uci -q delete dhcp.lan.dhcp_option
+
+# Remove DNS forwarding to 10.64.0.1
+uci -q delete dhcp.@dnsmasq[0].server
+
+# Restore the original firewall configuration from firewall.orig
+cat firewall.orig > /etc/config/firewall
+
+# Commit changes
+uci commit network
+uci commit firewall
+uci commit dhcp
+
+# Restart network service
+/etc/init.d/network restart
+
+# Restart firewall service
+/etc/init.d/firewall restart
+/etc/init.d/dnsmasq restart
+
+echo "WireGuard VPN stopped. You now have normal internet access."


### PR DESCRIPTION
Title: Added start-vpn.ash and stop-vpn.ash scripts for WireGuard VPN setup

Description:
This pull request adds two new scripts, start-vpn.ash and stop-vpn.ash, to facilitate the setup and termination of WireGuard VPN on routers. These scripts are designed to work with OpenWrt routers and aim to streamline the configuration process for users.

start-vpn.ash Script:
The start-vpn.ash script installs the required packages (wireguard-tools, luci-proto-wireguard, and curl), generates WireGuard key pairs, establishes the VPN connection using Mullvad's API, configures the WireGuard interface, adds a peer configuration, sets up firewall rules, and enables DNS forwarding. The script concludes by restarting the network, firewall, and DNS services.

stop-vpn.ash Script:
The stop-vpn.ash script undoes the changes made by start-vpn.ash, removing the WireGuard interface and peer configuration, deleting firewall zones, forwarding rules, and DHCP-Options. It also restores the original firewall configuration from the firewall.orig file and restarts the network, firewall, and DNS services to ensure normal internet access is restored.
