### PR TITLE
added ip/ssid fetch files to router

### DIFF
--- a/router/get_local_ip.ash
+++ b/router/get_local_ip.ash
@@ -1,0 +1,5 @@
+#!/bin/ash
+echo "Content-type: application/json"
+echo "Access-Control-Allow-Origin: *"
+echo ""
+echo "{ \"ip\": \"$REMOTE_ADDR\" }"

--- a/router/get_wifi_ssid.ash
+++ b/router/get_wifi_ssid.ash
@@ -1,0 +1,7 @@
+#!/bin/ash
+echo "Content-type: application/json"
+echo "Access-Control-Allow-Origin: *"
+echo ""
+
+SSID=$(iwinfo phy1-ap0 info | grep 'SSID' | awk -F '"' '{print $2}')
+echo "{ \"ssid\": \"$SSID\" }"


### PR DESCRIPTION
Adding 2 files to the router repository:
- get_local_ip.ash: return the ip of the requesting client
- get_wifi_ssid.ash: return the ssid of the router

TODO: Change the configure.ash to put these files in /www/cgi-bin/ , run chmod +x on both files and restart uhttpd using `/etc/init.d/uhttpd restart`

Prereq. : `opkg install iwinfo`