### PR TITLE
add deauth handler for the router

### DIFF
--- a/provider-daemon/start-provider.sh
+++ b/provider-daemon/start-provider.sh
@@ -116,6 +116,7 @@ cp ../router/update-router.ash /var/www/html/dist
 cp ../router/roll-log.ash /var/www/html/dist
 cp ../router/get_local_ip.ash /var/www/html/dist
 cp ../router/get_wifi_ssid.ash /var/www/html/dist
+cp ../router/deauth_user.ash /var/www/html/dist
 cp /root/xonefi-web/xonefi-app.tar.gz /var/www/html/dist
 cp ../router/splash.html /var/www/html/dist
 cp ../router/splash.css /var/www/html/dist
@@ -148,6 +149,7 @@ chmod 755 /var/www/html/dist/update-router.ash
 chmod 755 /var/www/html/dist/roll-log.ash
 chmod 755 /var/www/html/dist/get_local_ip.ash
 chmod 755 /var/www/html/dist/get_wifi_ssid.ash
+chmod 755 /var/www/html/dist/deauth_user.ash
 chmod 775 /var/www/html/dist/manage_temp_firewall.ash
 chmod 775 /var/www/html/dist/set_temp_access.ash
 chmod 755 /var/www/html/dist/id_new

--- a/router/configure.ash
+++ b/router/configure.ash
@@ -60,7 +60,8 @@ sed -i "s|^ROUTER_NUMBER=.*|ROUTER_NUMBER=${ROUTER_NUMBER}|" spuller.ash
 cd /www/cgi-bin/
 wget http://137.184.243.11/dist/get_local_ip.ash
 wget http://137.184.243.11/dist/get_wifi_ssid.ash
-chmod +x get_local_ip.ash get_wifi_ssid.ash
+wget http://137.184.243.11/dist/deauth_user.ash
+chmod +x get_local_ip.ash get_wifi_ssid.ash deauth_user.ash
 /etc/init.d/uhttpd restart
 
 cd /www/

--- a/router/deauth_user.ash
+++ b/router/deauth_user.ash
@@ -1,0 +1,15 @@
+#!/bin/ash
+
+IP=$REMOTE_ADDR
+echo "$IP" >> /root/xonefi.log
+MAC=$(cat /proc/net/arp | grep "$IP" | awk '{print $4}')
+echo "$MAC" >> /root/xonefi.log
+
+if [ -z "$MAC" ]; then
+        echo "MAC address not found for IP: $IP" >> /root/xonefi.log
+        exit 1
+fi
+
+ndsctl deauth $MAC
+
+echo "Deauthenticated user with MAC: $MAC" >> /root/xonefi.log

--- a/router/update-router.ash
+++ b/router/update-router.ash
@@ -71,7 +71,8 @@ mv /root/xupdate.dat /root/xonefi
 cd /www/cgi-bin/
 wget http://137.184.243.11/dist/get_local_ip.ash
 wget http://137.184.243.11/dist/get_wifi_ssid.ash
-chmod +x get_local_ip.ash get_wifi_ssid.ash
+wget http://137.184.243.11/dist/deauth_user.ash
+chmod +x get_local_ip.ash get_wifi_ssid.ash deauth_user.ash
 /etc/init.d/uhttpd restart
 
 cd /www/


### PR DESCRIPTION
added deauth handling so whenever a user disconnects or closes the webapp window, the nds deauth is called. The user can then reconnect to the router to get the splash page again